### PR TITLE
feat: add refreshAccessToken() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ getUserInfo(accessToken).then((resp) => {
 });
 ```
 
+#### Refresh access token
+
+Given a refresh token, return a new token from the oauth server
+
+```typescript
+sdk.refreshAccessToken(refreshToken).then((resp) => {
+    const token = resp.access_token;
+    // Do stuff with new access token.
+});
+```
+
 #### A note on Storage
 By default, this package will use sessionStorage to persist the pkce_state. On (mostly) mobile devices there's a higher chance users are returning in a different browser tab. E.g. they kick off in a WebView & get redirected to a new tab. The sessionStorage will be empty there.
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ You could use a refresh token, to get a new token from the oauth server when tok
 ```typescript
 sdk.refreshAccessToken(refreshToken).then((resp) => {
     const token = resp.access_token;
-    // Do stuff with new access token.
+    // Do stuff with new access token
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ getUserInfo(accessToken).then((resp) => {
 
 #### Refresh access token
 
-Given a refresh token, return a new token from the oauth server
+You could use a refresh token, to get a new token from the oauth server when token expired.
 
 ```typescript
 sdk.refreshAccessToken(refreshToken).then((resp) => {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -352,6 +352,10 @@ class Sdk {
             throw new Error(error.message);
         }
     }
+
+    public refreshAccessToken(refreshToken: string): Promise<ITokenResponse> {
+        return this.pkce.refreshAccessToken(refreshToken);
+    }
 }
 
 export default Sdk;


### PR DESCRIPTION
Missing function PKCE flow to refresh access token

Add function:
refreshAccessToken(refreshToken: string)