### PR TITLE
feat: Use `location.assign` instead of `location.replace` for `signin_redirect`

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -325,7 +325,7 @@ class Sdk {
     }
 
     public async signin_redirect(additionalParams?: IObject): Promise<void> {
-        window.location.replace(this.pkce.authorizeUrl(additionalParams));
+        window.location.assign(this.pkce.authorizeUrl(additionalParams));
     }
 
     public async exchangeForAccessToken(additionalParams?: IObject): Promise<ITokenResponse> {


### PR DESCRIPTION
Currently `Sdk.signin_redirect` uses `location.replace` to do redirection, which prevents the user from navigating back to the current page after being redirected to the login page.

This PR changes it to `location.assign` to preserve the history.